### PR TITLE
Add ranking page and fix mobile menu overlap

### DIFF
--- a/components/Menu.js
+++ b/components/Menu.js
@@ -33,6 +33,7 @@ export default function Menu() {
     { name: 'Perfil', path: '/perfil' },
     { name: 'Treinos', path: '/treinos' },
     { name: 'Meus Treinos', path: '/meus-treinos' },
+    { name: 'Ranking', path: '/ranking' },
     { name: 'Painel', path: '/painel' },
     { name: 'Pagamento', path: '/pagamento' },
   ];

--- a/components/Menu.module.css
+++ b/components/Menu.module.css
@@ -107,7 +107,7 @@
 
 @media (max-width: 768px) {
   .menuBar {
-    position: fixed;
+    position: sticky;
   }
   .menuInner {
     flex-direction: column;

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -210,8 +210,18 @@ export default function Admin() {
                   <div className="small text-muted mt-1">{t.metodologia}</div>
                 </div>
                 <div className="d-flex gap-2">
-                  <button className="btn btn-secondary btn-sm">Editar</button>
-                  <button className="btn btn-danger btn-sm">Remover</button>
+                  <button
+                    className="btn btn-secondary btn-sm"
+                    onClick={() => startEdit(t)}
+                  >
+                    Editar
+                  </button>
+                  <button
+                    className="btn btn-danger btn-sm"
+                    onClick={() => removerTreino(t.id)}
+                  >
+                    Remover
+                  </button>
                 </div>
               </li>
             )

--- a/pages/alunos.js
+++ b/pages/alunos.js
@@ -36,6 +36,7 @@ export default function Alunos() {
   const [email, setEmail] = useState("");
   const [pagamento, setPagamento] = useState("");
   const [telefone, setTelefone] = useState("");
+  const [pontuacao, setPontuacao] = useState(0);
   const [alunos, setAlunos] = useState([]);
   const [msg, setMsg] = useState("");
   const [editId, setEditId] = useState(null);
@@ -43,6 +44,7 @@ export default function Alunos() {
   const [editEmail, setEditEmail] = useState("");
   const [editPagamento, setEditPagamento] = useState("");
   const [editTelefone, setEditTelefone] = useState("");
+  const [editPontuacao, setEditPontuacao] = useState(0);
 
   useEffect(() => {
     async function fetchAlunos() {
@@ -60,9 +62,10 @@ export default function Alunos() {
       email,
       pagamento,
       telefone,
+      pontuacao: Number(pontuacao),
     });
     setMsg("Aluno cadastrado!");
-    setNome(""); setEmail(""); setPagamento(""); setTelefone("");
+    setNome(""); setEmail(""); setPagamento(""); setTelefone(""); setPontuacao(0);
     setTimeout(() => setMsg(""), 1500);
   }
 
@@ -78,6 +81,7 @@ export default function Alunos() {
     setEditEmail(a.email);
     setEditPagamento(a.pagamento);
     setEditTelefone(a.telefone);
+    setEditPontuacao(a.pontuacao || 0);
   }
 
   async function salvarEdicao(e) {
@@ -87,6 +91,7 @@ export default function Alunos() {
       email: editEmail,
       pagamento: editPagamento,
       telefone: editTelefone,
+      pontuacao: Number(editPontuacao),
     });
     setMsg("Aluno editado!");
     setEditId(null);
@@ -142,6 +147,15 @@ export default function Alunos() {
               onChange={e => setTelefone(e.target.value)}
             />
           </div>
+          <div className="col-12 col-md-6">
+            <input
+              type="number"
+              className="form-control"
+              placeholder="Pontuação"
+              value={pontuacao}
+              onChange={e => setPontuacao(e.target.value)}
+            />
+          </div>
           <div className="col-12">
             <button type="submit" className="btn btn-primary w-100">
               Cadastrar
@@ -150,6 +164,58 @@ export default function Alunos() {
         </form>
 
         {msg && <div className="alert alert-secondary text-center">{msg}</div>}
+
+        {editId && (
+          <form onSubmit={salvarEdicao} className="row g-3 mb-4">
+            <div className="col-12 col-md-6">
+              <input
+                type="text"
+                className="form-control"
+                value={editNome}
+                onChange={e => setEditNome(e.target.value)}
+                required
+              />
+            </div>
+            <div className="col-12 col-md-6">
+              <input
+                type="email"
+                className="form-control"
+                value={editEmail}
+                onChange={e => setEditEmail(e.target.value)}
+                required
+              />
+            </div>
+            <div className="col-12 col-md-6">
+              <input
+                type="date"
+                className="form-control"
+                value={editPagamento}
+                onChange={e => setEditPagamento(e.target.value)}
+                required
+              />
+            </div>
+            <div className="col-12 col-md-6">
+              <input
+                type="tel"
+                className="form-control"
+                value={editTelefone}
+                onChange={e => setEditTelefone(e.target.value)}
+              />
+            </div>
+            <div className="col-12 col-md-6">
+              <input
+                type="number"
+                className="form-control"
+                value={editPontuacao}
+                onChange={e => setEditPontuacao(e.target.value)}
+              />
+            </div>
+            <div className="col-12 d-flex gap-2">
+              <button type="submit" className="btn btn-primary flex-fill">Salvar</button>
+              <button type="button" className="btn btn-secondary flex-fill" onClick={() => setEditId(null)}>Cancelar</button>
+            </div>
+          </form>
+        )}
 
         {/* Lista */}
         <h5 className="text-center mb-3" style={{ color: 'var(--link-color)' }}>
@@ -166,6 +232,9 @@ export default function Alunos() {
                 </span><br />
                 <span className="text-muted">
                   {a.telefone || 'Sem telefone'}
+                </span><br />
+                <span className="text-muted">
+                  Pontuação: {a.pontuacao || 0}
                 </span>
               </div>
               <div className="d-flex gap-2">

--- a/pages/ranking.js
+++ b/pages/ranking.js
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { db } from '@/lib/firebaseConfig';
+import { collection, getDocs, orderBy, query } from 'firebase/firestore';
+
+export default function Ranking() {
+  const [alunos, setAlunos] = useState([]);
+
+  useEffect(() => {
+    async function fetchRanking() {
+      const q = query(collection(db, 'alunos'), orderBy('pontuacao', 'desc'));
+      const snap = await getDocs(q);
+      setAlunos(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+    }
+    fetchRanking();
+  }, []);
+
+  return (
+    <div className="container py-4">
+      <div className="mx-auto" style={{ maxWidth: '600px', width: '100%' }}>
+        <h1 className="text-center mb-4" style={{ color: 'var(--link-color)' }}>
+          Ranking de Alunos
+        </h1>
+        <ol className="list-group list-group-numbered">
+          {alunos.map(a => (
+            <li
+              key={a.id}
+              className="list-group-item d-flex justify-content-between align-items-center"
+            >
+              <span>{a.nome}</span>
+              <span className="badge bg-primary rounded-pill">{a.pontuacao || 0}</span>
+            </li>
+          ))}
+          {alunos.length === 0 && (
+            <li className="list-group-item text-center text-muted">
+              Nenhum aluno cadastrado.
+            </li>
+          )}
+        </ol>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- prevent mobile menu from covering content
- allow managing student points and ranking
- fix broken edit actions in admin pages

## Testing
- `npm run lint` *(fails: requires interactive ESLint config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ba4d5727c832888c077d8cfe03b6a